### PR TITLE
Add UUIDv7 prefix support

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,29 +38,33 @@
       <p id="uuidv7-error" class="alert alert-danger" style="display: none;">UUID does not encode a valid timestamp. <a class="alert-link reset-to-now" href="#">Reset to a UUIDv7 encoding the current timestamp.</a></p>
       <p id="warning" class="alert alert-info" style="display: none;">Interpreting as seconds.</p>
       <div id="clickable">
-        <ul class="list-group">
-          <li id="default-output" class="list-group-item list-group-item-action list-group-item-primary" href="#">Loading...</li>
-          <li class="list-group-item list-group-item-action" href="#">
-            <label class="list-group-item-label quiet">Readable</label>
-            <span id="readable-output"></span>
-          </li>
-          <li class="list-group-item list-group-item-action" href="#">
-            <label class="list-group-item-label quiet">ISO 8601</label>
-            <span id="iso-output"></span>
-          </li>
-          <li class="list-group-item list-group-item-action" href="#">
-            <label class="list-group-item-label quiet">JavaScript</label>
-            <code id="code-output"></code>
-          </li>
-          <li class="list-group-item list-group-item-action" href="#">
-            <label class="list-group-item-label quiet">Mongo ID</label>
-            <code id="mongo-output"></code>
-          </li>
-          <li class="list-group-item list-group-item-action" href="#">
-            <label class="list-group-item-label quiet">UUIDv7</label>
-            <code id="uuidv7-output"></code>
-          </li>
-        </ul>
+        <table class="output-table">
+          <tbody>
+            <tr id="default-row">
+              <td id="default-output" colspan="2">Loading...</td>
+            </tr>
+            <tr>
+              <th scope="row" class="quiet">Readable</th>
+              <td><span id="readable-output"></span></td>
+            </tr>
+            <tr>
+              <th scope="row" class="quiet">ISO 8601</th>
+              <td><span id="iso-output"></span></td>
+            </tr>
+            <tr>
+              <th scope="row" class="quiet">JavaScript</th>
+              <td><code id="code-output"></code></td>
+            </tr>
+            <tr>
+              <th scope="row" class="quiet">UUIDv7</th>
+              <td><code id="uuidv7-output"></code></td>
+            </tr>
+            <tr>
+              <th scope="row" class="quiet">Mongo ID</th>
+              <td><code id="mongo-output"></code></td>
+            </tr>
+          </tbody>
+        </table>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
             <a id="switch-to-unix" class="dropdown-item" href="#">Unix Time</a>
             <a id="switch-to-iso" class="dropdown-item" href="#">ISO 8601</a>
             <a id="switch-to-mongo" class="dropdown-item" href="#">Mongo ID</a>
+            <a id="switch-to-uuidv7" class="dropdown-item" href="#">UUIDv7</a>
           </div>
         </div>
         <input id="input" class="form-control" type="number" aria-label="Timestamp" aria-describedby="basic-addon1">
@@ -34,6 +35,7 @@
       <p id="unix-error" class="alert alert-danger" style="display: none;">Timestamp is not valid. <a class="alert-link reset-to-now" href="#">Reset to the current timestamp.</a></p>
       <p id="iso-error" class="alert alert-danger" style="display: none;">ISO time is not valid. <a class="alert-link reset-to-now" href="#">Reset to the current time.</a></p>
       <p id="mongo-error" class="alert alert-danger" style="display: none;">ID does not encode a valid timestamp. <a class="alert-link reset-to-now" href="#">Reset to a Mongo ID encoding the current timetamp.</a></p>
+      <p id="uuidv7-error" class="alert alert-danger" style="display: none;">UUID does not encode a valid timestamp. <a class="alert-link reset-to-now" href="#">Reset to a UUIDv7 encoding the current timestamp.</a></p>
       <p id="warning" class="alert alert-info" style="display: none;">Interpreting as seconds.</p>
       <div id="clickable">
         <ul class="list-group">
@@ -53,6 +55,10 @@
           <li class="list-group-item list-group-item-action" href="#">
             <label class="list-group-item-label quiet">Mongo ID</label>
             <code id="mongo-output"></code>
+          </li>
+          <li class="list-group-item list-group-item-action" href="#">
+            <label class="list-group-item-label quiet">UUIDv7</label>
+            <code id="uuidv7-output"></code>
           </li>
         </ul>
       </div>

--- a/style.css
+++ b/style.css
@@ -6,16 +6,51 @@
   color: #95a5a6;
 }
 
-.list-group-item-label {
-  display: inline-block;
-  min-width: 6em;
-  margin-right: 20px;
-  margin-bottom: 0;
-  /* Unselectable */
+/* Output table. Two columns: a label header on the left and the value on
+ * the right. The browser sizes both columns to their content, which gives
+ * us the alignment we want without any hard-coded widths. */
+.output-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+.output-table th,
+.output-table td {
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid rgba(0, 0, 0, 0.125);
+  text-align: left;
+  vertical-align: baseline;
+  font-weight: normal;
+}
+.output-table tr:first-child th,
+.output-table tr:first-child td {
+  border-top: 0;
+}
+.output-table th {
+  /* Auto-size label column to widest label. */
+  width: 1%;
+  white-space: nowrap;
+  /* Labels are not selectable. */
   -webkit-touch-callout: none;
   -webkit-user-select: none;
-  -khtml-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
+}
+.output-table tbody tr:hover {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+/* The primary (first) row mirrors Bootstrap's list-group-item-primary look. */
+#default-row td {
+  background-color: #b8daff;
+  color: #004085;
+  border-top: 0;
+  border-radius: 0.25rem 0.25rem 0 0;
+}
+
+/* Outer table-as-list look: rounded corners + thin border on the table. */
+#clickable .output-table {
+  border: 1px solid rgba(0, 0, 0, 0.125);
+  border-radius: 0.25rem;
+  overflow: hidden;
 }

--- a/style.css
+++ b/style.css
@@ -7,6 +7,8 @@
 }
 
 .list-group-item-label {
+  display: inline-block;
+  min-width: 6em;
   margin-right: 20px;
   margin-bottom: 0;
   /* Unselectable */

--- a/style.css
+++ b/style.css
@@ -56,8 +56,11 @@
   border-radius: 0.25rem 0.25rem 0 0;
 }
 
-/* Outer table-as-list look: rounded corners + thin border on the table. */
-#clickable .output-table {
+/* Outer table-as-list look: rounded corners + thin border. Putting the
+ * border on the wrapper (rather than on <table border-collapse: collapse>)
+ * avoids the well-known issue where the outer border doesn't render
+ * alongside the radius/overflow clipping. */
+#clickable {
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem;
   overflow: hidden;

--- a/style.css
+++ b/style.css
@@ -21,6 +21,14 @@
   vertical-align: baseline;
   font-weight: normal;
 }
+/* Halve the inter-column gap by tightening the label's right padding
+ * and the value's left padding. Outer padding (table edges) is unchanged. */
+.output-table th {
+  padding-right: 0.625rem;
+}
+.output-table td:not(:first-child) {
+  padding-left: 0.625rem;
+}
 .output-table tr:first-child th,
 .output-table tr:first-child td {
   border-top: 0;

--- a/unified.js
+++ b/unified.js
@@ -23,6 +23,13 @@ const mongoParser = (s) => {
   return new Date(ms);
 }
 
+const uuidv7Parser = (s) => {
+  // Strip dashes; first 12 hex digits encode unix ms timestamp.
+  const hex = s.replace(/-/g, "");
+  const ms = parseInt(hex.substring(0, 12), 16);
+  return new Date(ms);
+}
+
 const isoParser = (s) => new Date(s);
 
 var error;
@@ -60,12 +67,22 @@ const toMongoOutput = (d) => {
   return prefix + "0000000000000000";
 }
 
+const toUUIDv7Output = (d) => {
+  // Emit the lexicographically-minimum well-formed UUIDv7 for this ms, so
+  // the value works as a sentinel for range queries on a UUIDv7 ID column
+  // (e.g. `WHERE id >= <uuid>` selects records at or after this timestamp).
+  // 48-bit ms timestamp, version nibble 7, variant bits 10xx, rest zero.
+  const tsHex = d.getTime().toString(16).padStart(12, "0");
+  return `${tsHex.substring(0, 8)}-${tsHex.substring(8, 12)}-7000-8000-000000000000`;
+}
+
 const outputsAndGenerators = new Map([
   [document.getElementById('default-output'), toDefaultOutput],
   [document.getElementById('code-output'), toCodeOutput],
   [document.getElementById('readable-output'), toReadableOutput],
   [document.getElementById('iso-output'), toISOOutput],
   [document.getElementById('mongo-output'), toMongoOutput],
+  [document.getElementById('uuidv7-output'), toUUIDv7Output],
 ]);
 
 /**
@@ -110,6 +127,9 @@ const isoError = document.getElementById("iso-error");
 const switchToMongoLink = document.getElementById("switch-to-mongo");
 const mongoError = document.getElementById("mongo-error");
 
+const switchToUUIDv7Link = document.getElementById("switch-to-uuidv7");
+const uuidv7Error = document.getElementById("uuidv7-error");
+
 // (String | Number) => Date
 var inputParser;
 // (Date) => String | Number
@@ -124,6 +144,7 @@ function switchToUnix() {
   switchToUnixLink.classList.add("active");
   switchToISOLink.classList.remove("active");
   switchToMongoLink.classList.remove("active");
+  switchToUUIDv7Link.classList.remove("active");
   error = unixError;
 }
 
@@ -140,6 +161,7 @@ function switchToISO() {
   switchToISOLink.classList.add("active");
   switchToUnixLink.classList.remove("active");
   switchToMongoLink.classList.remove("active");
+  switchToUUIDv7Link.classList.remove("active");
   error = isoError;
 }
 
@@ -156,11 +178,29 @@ function switchToMongo() {
   switchToMongoLink.classList.add("active");
   switchToUnixLink.classList.remove("active");
   switchToISOLink.classList.remove("active");
+  switchToUUIDv7Link.classList.remove("active");
   error = mongoError;
 }
 
 switchToMongoLink.addEventListener('click', () => {
   switchToMongo();
+  reset();
+});
+
+function switchToUUIDv7() {
+  dropdown.innerText = "UUIDv7";
+  input.type = "text"
+  inputParser = uuidv7Parser;
+  dateToValidInput = toUUIDv7Output;
+  switchToUUIDv7Link.classList.add("active");
+  switchToUnixLink.classList.remove("active");
+  switchToISOLink.classList.remove("active");
+  switchToMongoLink.classList.remove("active");
+  error = uuidv7Error;
+}
+
+switchToUUIDv7Link.addEventListener('click', () => {
+  switchToUUIDv7();
   reset();
 });
 
@@ -179,6 +219,9 @@ if (queried && queried.length > 0) {
   } else if (!isNaN((new Date(queried)).getTime())) {
     console.log("Switching on query to ISO");
     switchToISO();
+  } else if (/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(queried)) {
+    console.log("Switching on query to UUIDv7");
+    switchToUUIDv7();
   } else {
     console.log("Defaulting on query to Mongo");
     switchToMongo();


### PR DESCRIPTION
Adds a UUIDv7 mode alongside the existing Mongo ID support. UUIDv7 encodes a 48-bit Unix-ms timestamp in its first 12 hex digits, so the timestamp portion can be parsed/emitted analogously to a Mongo ObjectId.

Emits the **lexicographically-minimum well-formed UUIDv7** for the given timestamp:

```
<ts-hi>-<ts-lo>-7000-8000-000000000000
```

Version nibble `7`, variant bits `10xx` (`8`), remaining bits zero. This makes the output usable as a sentinel value for range queries on a UUIDv7 ID column — e.g. `WHERE id >= <uuid>` selects all records created at or after the timestamp.

The output area is restructured from a Bootstrap `list-group` + `<li>`s into an HTML `<table>`. The browser auto-sizes both columns to their content, so labels and values line up across rows without any hard-coded widths.