### PR TITLE
Replace Readable row with relative time

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
               <td id="default-output" colspan="3">Loading...</td>
             </tr>
             <tr id="relative-row">
-              <th scope="row" class="quiet"><span id="relative-refresh" title="Click to refresh for current time">Relative</span></th>
+              <th scope="row" class="quiet"><span id="relative-refresh" title="Refresh">Relative</span></th>
               <td><span id="relative-compound-output"></span></td>
               <td><span id="relative-seconds-output" class="quiet"></span></td>
             </tr>

--- a/index.html
+++ b/index.html
@@ -44,8 +44,7 @@
               <td id="default-output" colspan="2">Loading...</td>
             </tr>
             <tr id="relative-row" title="Click to toggle between compound units and seconds">
-              <th scope="row" class="quiet">Relative</th>
-              <td><span id="relative-output"></span></td>
+              <td colspan="2"><span id="relative-output"></span></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">ISO 8601</th>

--- a/index.html
+++ b/index.html
@@ -41,27 +41,28 @@
         <table class="output-table">
           <tbody>
             <tr id="default-row">
-              <td id="default-output" colspan="2">Loading...</td>
+              <td id="default-output" colspan="3">Loading...</td>
             </tr>
-            <tr id="relative-row" title="Click to toggle between compound units and seconds">
-              <th scope="row" class="quiet">Relative</th>
-              <td><span id="relative-output"></span></td>
+            <tr id="relative-row">
+              <th scope="row" class="quiet"><span id="relative-refresh" title="Click to refresh for current time">Relative</span></th>
+              <td><span id="relative-compound-output"></span></td>
+              <td><span id="relative-seconds-output" class="quiet"></span></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">ISO 8601</th>
-              <td><span id="iso-output"></span></td>
+              <td colspan="2"><span id="iso-output"></span></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">JavaScript</th>
-              <td><code id="code-output"></code></td>
+              <td colspan="2"><code id="code-output"></code></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">UUIDv7</th>
-              <td><code id="uuidv7-output"></code></td>
+              <td colspan="2"><code id="uuidv7-output"></code></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">Mongo ID</th>
-              <td><code id="mongo-output"></code></td>
+              <td colspan="2"><code id="mongo-output"></code></td>
             </tr>
           </tbody>
         </table>

--- a/index.html
+++ b/index.html
@@ -43,9 +43,9 @@
             <tr id="default-row">
               <td id="default-output" colspan="2">Loading...</td>
             </tr>
-            <tr>
-              <th scope="row" class="quiet">Readable</th>
-              <td><span id="readable-output"></span></td>
+            <tr id="relative-row" title="Click to toggle between compound units and seconds">
+              <th scope="row" class="quiet">Relative</th>
+              <td><span id="relative-output"></span></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">ISO 8601</th>

--- a/index.html
+++ b/index.html
@@ -44,7 +44,8 @@
               <td id="default-output" colspan="2">Loading...</td>
             </tr>
             <tr id="relative-row" title="Click to toggle between compound units and seconds">
-              <td colspan="2"><span id="relative-output"></span></td>
+              <th scope="row" class="quiet">Relative</th>
+              <td><span id="relative-output"></span></td>
             </tr>
             <tr>
               <th scope="row" class="quiet">ISO 8601</th>

--- a/style.css
+++ b/style.css
@@ -69,3 +69,13 @@
 #relative-row {
   cursor: pointer;
 }
+
+/* Lighter grey for past timestamps than Bootstrap's default secondary. */
+#relative-row.list-group-item-secondary {
+  background-color: #eef0f1;
+  color: #6c757d;
+}
+#relative-row.list-group-item-secondary:hover,
+#relative-row.list-group-item-secondary:focus {
+  background-color: #e3e6e8;
+}

--- a/style.css
+++ b/style.css
@@ -80,3 +80,7 @@
   cursor: pointer;
   border-bottom: 1px dotted currentColor;
 }
+
+#relative-row td:last-child {
+  text-align: right;
+}

--- a/style.css
+++ b/style.css
@@ -65,3 +65,7 @@
   border-radius: 0.25rem;
   overflow: hidden;
 }
+
+#relative-row {
+  cursor: pointer;
+}

--- a/style.css
+++ b/style.css
@@ -66,10 +66,6 @@
   overflow: hidden;
 }
 
-#relative-row {
-  cursor: pointer;
-}
-
 /* Lighter grey for past timestamps than Bootstrap's default secondary. */
 #relative-row.list-group-item-secondary {
   background-color: #eef0f1;
@@ -78,4 +74,9 @@
 #relative-row.list-group-item-secondary:hover,
 #relative-row.list-group-item-secondary:focus {
   background-color: #e3e6e8;
+}
+
+#relative-refresh {
+  cursor: pointer;
+  border-bottom: 1px dotted currentColor;
 }

--- a/style.css
+++ b/style.css
@@ -84,3 +84,9 @@
 #relative-row td:last-child {
   text-align: right;
 }
+
+/* Tabular numerals so updating values don't shift horizontally. */
+.output-table,
+#input {
+  font-variant-numeric: tabular-nums;
+}

--- a/unified.js
+++ b/unified.js
@@ -91,10 +91,11 @@ const relativeRow = document.getElementById('relative-row');
 
 const toCompoundOutput = (d) => {
   const deltaMs = d.getTime() - Date.now();
-  // Highlight row: gray for past, sunny yellow for future.
+  const secs = Math.round(deltaMs / 1000);
+  // Highlight row: gray for past, sunny yellow for future, neutral at 'now'.
   relativeRow.classList.remove('list-group-item-secondary', 'list-group-item-warning');
-  if (!isNaN(d.getTime())) {
-    relativeRow.classList.add(deltaMs >= 0 ? 'list-group-item-warning' : 'list-group-item-secondary');
+  if (!isNaN(d.getTime()) && secs !== 0) {
+    relativeRow.classList.add(secs > 0 ? 'list-group-item-warning' : 'list-group-item-secondary');
   }
   return toCompoundString(deltaMs);
 };

--- a/unified.js
+++ b/unified.js
@@ -50,60 +50,61 @@ const toDefaultOutput = (d) => d;
 
 const toCodeOutput = (d) => `new Date(${d.getTime()})`;
 
-// Relative-time output. The coarsest unit where |value| >= 1 is chosen
-// by default; clicking the unit word cycles to finer (then wraps).
-const relativeUnits = [
-  ['year',   365.25 * 24 * 60 * 60 * 1000],
-  ['month',  30.4375 * 24 * 60 * 60 * 1000],
-  ['week',   7 * 24 * 60 * 60 * 1000],
+// Relative-time output. Two modes, toggled by clicking the row:
+//   'compound' — "2 days, 3 hours, 4 minutes, 5 seconds ago"
+//   'seconds'  — "183845 seconds ago"
+var relativeMode = 'compound';
+
+const compoundUnits = [
   ['day',    24 * 60 * 60 * 1000],
   ['hour',   60 * 60 * 1000],
   ['minute', 60 * 1000],
   ['second', 1000],
 ];
-const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
 
-// Index into relativeUnits for the currently displayed precision.
-// null means "auto-pick the coarsest meaningful unit". Stays null until the
-// user explicitly cycles, so changing the input re-picks the coarsest unit.
-var relativeUnitIndex = null;
+const pluralize = (n, unit) => `${n} ${unit}${n === 1 ? '' : 's'}`;
 
-const availableUnitsFor = (deltaMs) => {
-  // Units whose rounded value is non-zero. Falls back to 'second' if all round to 0.
-  const idxs = relativeUnits
-    .map(([, ms], i) => Math.round(deltaMs / ms) !== 0 ? i : -1)
-    .filter(i => i !== -1);
-  return idxs.length ? idxs : [relativeUnits.length - 1];
+const toCompoundString = (deltaMs) => {
+  let remaining = Math.abs(deltaMs);
+  // Round to the nearest second so we don't carry sub-second noise.
+  remaining = Math.round(remaining / 1000) * 1000;
+  if (remaining === 0) return 'now';
+  const parts = [];
+  for (const [unit, ms] of compoundUnits) {
+    const n = Math.floor(remaining / ms);
+    if (n > 0) {
+      parts.push(pluralize(n, unit));
+      remaining -= n * ms;
+    }
+  }
+  const joined = parts.join(', ');
+  return deltaMs < 0 ? `${joined} ago` : `in ${joined}`;
 };
+
+const toSecondsString = (deltaMs) => {
+  const secs = Math.round(deltaMs / 1000);
+  if (secs === 0) return 'now';
+  const n = Math.abs(secs);
+  const phrase = pluralize(n, 'second');
+  return secs < 0 ? `${phrase} ago` : `in ${phrase}`;
+};
+
+const relativeRow = document.getElementById('relative-row');
 
 const toReadableOutput = (d) => {
   const deltaMs = d.getTime() - Date.now();
-  const available = availableUnitsFor(deltaMs);
-  // Pick coarsest available if the user hasn't chosen, or if their choice
-  // isn't meaningful for this delta. Don't mutate relativeUnitIndex itself —
-  // we want a later, larger delta to re-pick the coarsest unit.
-  const idx = (relativeUnitIndex !== null && available.includes(relativeUnitIndex))
-    ? relativeUnitIndex
-    : available[0];
-  const [unit, unitMs] = relativeUnits[idx];
-  const value = Math.round(deltaMs / unitMs);
-  const formatted = rtf.format(value, unit);
-  // Make the unit word (or 'now') clickable for cycling precision.
-  const re = new RegExp('\\b(' + unit + 's?|now)\\b');
-  return formatted.replace(re, '<span class="relative-unit" role="button" tabindex="0">$1</span>');
+  // Highlight: gray for past, sunny yellow for future. Cleared if the row is
+  // marked invalid (we still emit a string in that case, but the date is NaN
+  // upstream and the whole output is replaced with 'Invalid Date').
+  relativeRow.classList.remove('list-group-item-secondary', 'list-group-item-warning');
+  if (!isNaN(d.getTime())) {
+    relativeRow.classList.add(deltaMs >= 0 ? 'list-group-item-warning' : 'list-group-item-secondary');
+  }
+  return relativeMode === 'seconds' ? toSecondsString(deltaMs) : toCompoundString(deltaMs);
 };
 
-const cycleRelativeUnit = () => {
-  const date = inputParser(input.value);
-  if (isNaN(date.getTime())) return;
-  const deltaMs = date.getTime() - Date.now();
-  const available = availableUnitsFor(deltaMs);
-  // If user hasn't cycled yet, current display is available[0]; advance from there.
-  const current = (relativeUnitIndex !== null && available.includes(relativeUnitIndex))
-    ? relativeUnitIndex
-    : available[0];
-  const pos = available.indexOf(current);
-  relativeUnitIndex = available[(pos + 1) % available.length];
+const toggleRelativeMode = () => {
+  relativeMode = relativeMode === 'compound' ? 'seconds' : 'compound';
   setOutputs();
 };
 
@@ -150,17 +151,13 @@ const setOutputs = () => {
 
 input.addEventListener('input', setOutputs);
 
-// Clicking the unit word in the relative-time output cycles precision.
-document.getElementById('relative-output').addEventListener('click', (e) => {
-  if (e.target.classList && e.target.classList.contains('relative-unit')) {
-    e.stopPropagation();
-    cycleRelativeUnit();
-  }
+// Clicking anywhere on the relative-time row toggles compound ↔ seconds.
+relativeRow.addEventListener('click', (e) => {
+  e.stopPropagation();
+  toggleRelativeMode();
 });
 
 const reset = () => {
-  // Re-pick coarsest unit on reset (typically a mode switch or error recovery).
-  relativeUnitIndex = null;
   input.value = dateToValidInput(new Date());
   setOutputs();
 }

--- a/unified.js
+++ b/unified.js
@@ -80,11 +80,13 @@ const toCompoundString = (deltaMs) => {
 };
 
 const toSecondsString = (deltaMs) => {
-  // Signed seconds with a truncated unit, e.g. "-1000 s" or "+42 s".
-  // Negative = in the past, positive = in the future.
-  const secs = Math.round(deltaMs / 1000);
-  const sign = secs > 0 ? '+' : '';
-  return `${sign}${secs} s`;
+  // Signed seconds with a truncated unit, e.g. "-1000.250 s" or "+42 s".
+  // Negative = in the past, positive = in the future. Up to 3 decimal
+  // places; trailing zeros (and the decimal point) are trimmed.
+  const secs = deltaMs / 1000;
+  let str = secs.toFixed(3).replace(/\.?0+$/, '');
+  if (secs > 0) str = '+' + str;
+  return `${str} s`;
 };
 
 const relativeRow = document.getElementById('relative-row');

--- a/unified.js
+++ b/unified.js
@@ -80,11 +80,11 @@ const toCompoundString = (deltaMs) => {
 };
 
 const toSecondsString = (deltaMs) => {
+  // Signed seconds with a truncated unit, e.g. "-1000 s" or "+42 s".
+  // Negative = in the past, positive = in the future.
   const secs = Math.round(deltaMs / 1000);
-  if (secs === 0) return 'now';
-  const n = Math.abs(secs);
-  const phrase = pluralize(n, 'second');
-  return secs < 0 ? `${phrase} ago` : `in ${phrase}`;
+  const sign = secs > 0 ? '+' : '';
+  return `${sign}${secs} s`;
 };
 
 const relativeRow = document.getElementById('relative-row');

--- a/unified.js
+++ b/unified.js
@@ -50,11 +50,9 @@ const toDefaultOutput = (d) => d;
 
 const toCodeOutput = (d) => `new Date(${d.getTime()})`;
 
-// Relative-time output. Two modes, toggled by clicking the row:
-//   'compound' — "2 days, 3 hours, 4 minutes, 5 seconds ago"
-//   'seconds'  — "183845 seconds ago"
-var relativeMode = 'compound';
-
+// Relative-time output. Two cells side by side:
+//   compound — "2 days, 3 hours, 4 minutes, 5 seconds ago"
+//   seconds  — "183845 seconds ago"
 const compoundUnits = [
   ['day',    24 * 60 * 60 * 1000],
   ['hour',   60 * 60 * 1000],
@@ -91,22 +89,17 @@ const toSecondsString = (deltaMs) => {
 
 const relativeRow = document.getElementById('relative-row');
 
-const toReadableOutput = (d) => {
+const toCompoundOutput = (d) => {
   const deltaMs = d.getTime() - Date.now();
-  // Highlight: gray for past, sunny yellow for future. Cleared if the row is
-  // marked invalid (we still emit a string in that case, but the date is NaN
-  // upstream and the whole output is replaced with 'Invalid Date').
+  // Highlight row: gray for past, sunny yellow for future.
   relativeRow.classList.remove('list-group-item-secondary', 'list-group-item-warning');
   if (!isNaN(d.getTime())) {
     relativeRow.classList.add(deltaMs >= 0 ? 'list-group-item-warning' : 'list-group-item-secondary');
   }
-  return relativeMode === 'seconds' ? toSecondsString(deltaMs) : toCompoundString(deltaMs);
+  return toCompoundString(deltaMs);
 };
 
-const toggleRelativeMode = () => {
-  relativeMode = relativeMode === 'compound' ? 'seconds' : 'compound';
-  setOutputs();
-};
+const toSecondsOutput = (d) => toSecondsString(d.getTime() - Date.now());
 
 const toISOOutput = (d) => d.toISOString();
 
@@ -128,7 +121,8 @@ const toUUIDv7Output = (d) => {
 const outputsAndGenerators = new Map([
   [document.getElementById('default-output'), toDefaultOutput],
   [document.getElementById('code-output'), toCodeOutput],
-  [document.getElementById('relative-output'), toReadableOutput],
+  [document.getElementById('relative-compound-output'), toCompoundOutput],
+  [document.getElementById('relative-seconds-output'), toSecondsOutput],
   [document.getElementById('iso-output'), toISOOutput],
   [document.getElementById('mongo-output'), toMongoOutput],
   [document.getElementById('uuidv7-output'), toUUIDv7Output],
@@ -151,10 +145,11 @@ const setOutputs = () => {
 
 input.addEventListener('input', setOutputs);
 
-// Clicking anywhere on the relative-time row toggles compound ↔ seconds.
-relativeRow.addEventListener('click', (e) => {
+// Clicking the 'Relative' label refreshes the row against the current
+// wall-clock time (the rest of the outputs depend on the input value).
+document.getElementById('relative-refresh').addEventListener('click', (e) => {
   e.stopPropagation();
-  toggleRelativeMode();
+  setOutputs();
 });
 
 const reset = () => {

--- a/unified.js
+++ b/unified.js
@@ -50,14 +50,62 @@ const toDefaultOutput = (d) => d;
 
 const toCodeOutput = (d) => `new Date(${d.getTime()})`;
 
-const toReadableOutput = (d) => d.toLocaleDateString(
-  'en-US',
-  {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric'
-  }
-);
+// Relative-time output. The coarsest unit where |value| >= 1 is chosen
+// by default; clicking the unit word cycles to finer (then wraps).
+const relativeUnits = [
+  ['year',   365.25 * 24 * 60 * 60 * 1000],
+  ['month',  30.4375 * 24 * 60 * 60 * 1000],
+  ['week',   7 * 24 * 60 * 60 * 1000],
+  ['day',    24 * 60 * 60 * 1000],
+  ['hour',   60 * 60 * 1000],
+  ['minute', 60 * 1000],
+  ['second', 1000],
+];
+const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+// Index into relativeUnits for the currently displayed precision.
+// null means "auto-pick the coarsest meaningful unit". Stays null until the
+// user explicitly cycles, so changing the input re-picks the coarsest unit.
+var relativeUnitIndex = null;
+
+const availableUnitsFor = (deltaMs) => {
+  // Units whose rounded value is non-zero. Falls back to 'second' if all round to 0.
+  const idxs = relativeUnits
+    .map(([, ms], i) => Math.round(deltaMs / ms) !== 0 ? i : -1)
+    .filter(i => i !== -1);
+  return idxs.length ? idxs : [relativeUnits.length - 1];
+};
+
+const toReadableOutput = (d) => {
+  const deltaMs = d.getTime() - Date.now();
+  const available = availableUnitsFor(deltaMs);
+  // Pick coarsest available if the user hasn't chosen, or if their choice
+  // isn't meaningful for this delta. Don't mutate relativeUnitIndex itself —
+  // we want a later, larger delta to re-pick the coarsest unit.
+  const idx = (relativeUnitIndex !== null && available.includes(relativeUnitIndex))
+    ? relativeUnitIndex
+    : available[0];
+  const [unit, unitMs] = relativeUnits[idx];
+  const value = Math.round(deltaMs / unitMs);
+  const formatted = rtf.format(value, unit);
+  // Make the unit word (or 'now') clickable for cycling precision.
+  const re = new RegExp('\\b(' + unit + 's?|now)\\b');
+  return formatted.replace(re, '<span class="relative-unit" role="button" tabindex="0">$1</span>');
+};
+
+const cycleRelativeUnit = () => {
+  const date = inputParser(input.value);
+  if (isNaN(date.getTime())) return;
+  const deltaMs = date.getTime() - Date.now();
+  const available = availableUnitsFor(deltaMs);
+  // If user hasn't cycled yet, current display is available[0]; advance from there.
+  const current = (relativeUnitIndex !== null && available.includes(relativeUnitIndex))
+    ? relativeUnitIndex
+    : available[0];
+  const pos = available.indexOf(current);
+  relativeUnitIndex = available[(pos + 1) % available.length];
+  setOutputs();
+};
 
 const toISOOutput = (d) => d.toISOString();
 
@@ -79,7 +127,7 @@ const toUUIDv7Output = (d) => {
 const outputsAndGenerators = new Map([
   [document.getElementById('default-output'), toDefaultOutput],
   [document.getElementById('code-output'), toCodeOutput],
-  [document.getElementById('readable-output'), toReadableOutput],
+  [document.getElementById('relative-output'), toReadableOutput],
   [document.getElementById('iso-output'), toISOOutput],
   [document.getElementById('mongo-output'), toMongoOutput],
   [document.getElementById('uuidv7-output'), toUUIDv7Output],
@@ -102,7 +150,17 @@ const setOutputs = () => {
 
 input.addEventListener('input', setOutputs);
 
+// Clicking the unit word in the relative-time output cycles precision.
+document.getElementById('relative-output').addEventListener('click', (e) => {
+  if (e.target.classList && e.target.classList.contains('relative-unit')) {
+    e.stopPropagation();
+    cycleRelativeUnit();
+  }
+});
+
 const reset = () => {
+  // Re-pick coarsest unit on reset (typically a mode switch or error recovery).
+  relativeUnitIndex = null;
   input.value = dateToValidInput(new Date());
   setOutputs();
 }


### PR DESCRIPTION
Replaces the "Readable" row (which mostly duplicated the ISO row) with a relative-duration row that shows two representations side by side. Roughly:

| Relative | compound | seconds-only |
|----------|----------|--------------|
| Relative | `2 days, 3 hours, 4 minutes, 5 seconds ago` | `-183845.123 s` |
| Relative | `in 1 hour` | `+3600 s` |
| Relative | `now` | `0 s` |

- **Compound cell** (primary): `D days, H hours, M minutes, S seconds` with zero-valued units omitted and a leading `in ` / trailing ` ago` for direction. `now` exactly at delta 0.
- **Seconds cell** (muted, right-aligned): signed value with a truncated unit (`-1000 s`, `+42 s`). Up to 3 decimal places; trailing zeros and the decimal point are trimmed (`+0.1 s`, not `+0.100 s`).

The row is highlighted:

- **Past** timestamps: light grey (custom override of `list-group-item-secondary` for a softer tone).
- **Future** timestamps: sunny yellow (`list-group-item-warning`).
- **`now`** (rounded to 0 seconds): neutral, no highlight.

Some minor polish:

- The "Relative" label has a dotted underline and `title="Refresh"`. Clicking it re-renders the row against the current wall-clock time — useful for seeing updated "N seconds ago" values without editing the input.
- Tabular numerals on the whole output table and the input, so updating digit values don't shift horizontally on Refresh / input edits.
