### PR TITLE
Minor fixes: UUIDv7 digit + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Some simple timestamp utilities.
 + Unix timestamps (milliseconds and seconds)
 + ISO 8601 timestamps
 + Mongo ID timestamps
++ UUIDv7 timestamps
 
 ## Search
 

--- a/unified.js
+++ b/unified.js
@@ -113,12 +113,19 @@ const toMongoOutput = (d) => {
 }
 
 const toUUIDv7Output = (d) => {
-  // Emit the lexicographically-minimum well-formed UUIDv7 for this ms, so
-  // the value works as a sentinel for range queries on a UUIDv7 ID column
-  // (e.g. `WHERE id >= <uuid>` selects records at or after this timestamp).
-  // 48-bit ms timestamp, version nibble 7, variant bits 10xx, rest zero.
+  // Emit a UUIDv7-shaped sentinel for this ms, suitable as a lower-bound
+  // for range queries on a UUIDv7 ID column (e.g. `WHERE id >= <sentinel>`
+  // selects records at or after this timestamp).
+  //
+  // The 48-bit ms timestamp occupies the leading 12 hex digits; the
+  // version nibble is 7; everything after that is zero. This isn't a
+  // valid UUIDv7 (the RFC 9562 variant nibble should be 10xx, i.e. 8-b)
+  // but that's the point: real UUIDv7s for this ms all sort STRICTLY
+  // ABOVE the sentinel (variant >= 8), and real UUIDv7s for ms-1 sort
+  // strictly below it (different timestamp prefix). So the sentinel is
+  // an exact lower bound for the ms with no false matches.
   const tsHex = d.getTime().toString(16).padStart(12, "0");
-  return `${tsHex.substring(0, 8)}-${tsHex.substring(8, 12)}-7000-8000-000000000000`;
+  return `${tsHex.substring(0, 8)}-${tsHex.substring(8, 12)}-7000-0000-000000000000`;
 }
 
 const outputsAndGenerators = new Map([


### PR DESCRIPTION
Two minor follow-ups to #2 / #3:

### Zero-pad the UUIDv7 output

The UUIDv7 row is meant to be a **lower-bound sentinel** for range queries on a UUIDv7 ID column. The original implementation emitted a well-formed UUIDv7 with variant nibble `8` (and the rest of the tail zero). That's RFC-valid, but it's also a real, sortable position **inside** the variant space — and real UUIDv7s in your database can have variant nibbles `8`, `9`, `a`, or `b` (the four values matching `10xx`). With variant `8`, two real UUIDv7s at the same ms with variants `9`/`a`/`b` would sort above the sentinel as intended, but the sentinel itself collides with the minimum real value.

This PR changes the variant (and everything else after the version nibble) to `0`:

```
<ts-hi>-<ts-lo>-7000-0000-000000000000
```

Properties:

- **Strictly less than every real UUIDv7 at this ms** (real variants are ≥ 8).
- **Strictly greater than every real UUIDv7 at ms − 1** (different timestamp prefix in the leading 12 hex digits).
- Therefore `WHERE id >= <sentinel>` selects exactly the records at or after this timestamp, with no false matches and no missed rows at the boundary.

The output isn't a valid UUIDv7 (variant should be `10xx` per RFC 9562). That's fine — it's never stored, only compared, and the obviously-fake shape is honest signaling that this is a sentinel.

### README

Adds UUIDv7 to the list of supported formats.
